### PR TITLE
创建 Updater.kt

### DIFF
--- a/app/src/main/java/com/lt2333/simplicitytools/hook/app/Updater.kt
+++ b/app/src/main/java/com/lt2333/simplicitytools/hook/app/Updater.kt
@@ -1,0 +1,29 @@
+package com.lt2333.simplicitytools.hook.app
+
+import com.lt2333.simplicitytools.util.XSPUtils
+import de.robv.android.xposed.IXposedHookLoadPackage
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage
+
+class Updater : IXposedHookLoadPackage {
+    override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        var letter = 'a'
+        for (i in 0..25) {
+            val classIfExists = XposedHelpers.findClassIfExists(
+                "com.android.updater.common.utils.$letter", lpparam.classLoader
+            ) ?: continue
+            if (classIfExists.declaredFields.size >= 9 && classIfExists.declaredMethods.size > 60) {
+                XposedHelpers.findAndHookMethod(classIfExists, "T", object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        if (XSPUtils.getBoolean("remove_ota_validate", false)) {
+                            param.result = false
+                        }
+                    }
+                })
+                return
+            }
+            letter++
+        }
+    }
+}


### PR DESCRIPTION
去除ota验证，仅支持vab机型。

无需校验内测资格刷入完整内测包。

目前稳定版需先线刷开发板才能升级到开发板，无法从稳定版直接切换到开发板， 使用此功能可从稳定版切换至开发板，建议在切换后恢复一次出厂设置。

有内测权限的使用本功能将无法收到内测更新，可用于屏蔽系统更新。